### PR TITLE
Bump GitHub Actions to Node 24 releases

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
         
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'images/'
           
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/generate-patriotic-image.yml
+++ b/.github/workflows/generate-patriotic-image.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
         


### PR DESCRIPTION
GitHub deprecated Node 20 on Actions runners and is force-running these on Node 24 with a warning.

Each action moves to the **lowest major that ships a `node24` runtime** — the smallest jump that clears the deprecation, rather than a blanket bump to latest.

Docker-based actions (super-linter) and actions already on node24 (`msys2/setup-msys2@v2`, `astral-sh/setup-uv@v8.1.0`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)