### PR TITLE
Add semgrep as an advisory check

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,42 @@
+---
+name: semgrep
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  scan:
+    name: semgrep
+    runs-on: ubuntu-latest
+    # Advisory only. The step never fails the job and the job never fails the
+    # run, so semgrep reports findings without gating a merge.
+    continue-on-error: true
+    permissions:
+      contents: read
+    container:
+      # Pinned by digest; the tag is here for readability only.
+      image: semgrep/semgrep@sha256:12672acdb0949e19f9f6a4c2b288edd0b404f268f0ca7738a2c06f372f50362e # v1.176.0
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job only reads the tree; no need to persist the token.
+          persist-credentials: false
+
+      - name: Scan
+        # p/default is semgrep's curated ruleset and needs no account or token.
+        # The trailing `|| true` is deliberate: a finding must not fail the step.
+        run: |
+          semgrep scan --config p/default --metrics=off --sarif --output semgrep.sarif . || true
+          echo "--- findings ---"
+          semgrep scan --config p/default --metrics=off --quiet . || true
+
+      - name: Upload SARIF
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: semgrep-sarif
+          path: semgrep.sarif
+          if-no-files-found: ignore


### PR DESCRIPTION
Non-blocking by construction: `continue-on-error: true` on the job and `|| true` on the scan step, so findings are reported without gating a merge. No autofix — semgrep only reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)